### PR TITLE
CHET-298: Allow users to select the Postgres engine version

### DIFF
--- a/templates/aurora_postgres-master.template.yaml
+++ b/templates/aurora_postgres-master.template.yaml
@@ -212,6 +212,8 @@ Parameters:
       - 10.5
       - 10.6
       - 10.7
+      - 11.4
+      - 11.6
   DBInstanceClass:
     AllowedValues:
       - db.r5.large

--- a/templates/aurora_postgres-master.template.yaml
+++ b/templates/aurora_postgres-master.template.yaml
@@ -214,6 +214,7 @@ Parameters:
       - 10.7
       - 11.4
       - 11.6
+      - 11.7
   DBInstanceClass:
     AllowedValues:
       - db.r5.large

--- a/templates/aurora_postgres.template.yaml
+++ b/templates/aurora_postgres.template.yaml
@@ -98,6 +98,10 @@ Mappings:
       "family": "aurora-postgresql10"
     "10.7":
       "family": "aurora-postgresql10"
+    "11.4":
+      "family": "aurora-postgresql11"
+    "11.6":
+      "family": "aurora-postgresql11"
 Conditions:
   IsDBMultiAZ:
     !Equals
@@ -170,6 +174,8 @@ Parameters:
       - 10.5
       - 10.6
       - 10.7
+      - 11.4
+      - 11.6
   DBInstanceClass:
     AllowedValues:
       - db.r5.large

--- a/templates/aurora_postgres.template.yaml
+++ b/templates/aurora_postgres.template.yaml
@@ -102,6 +102,8 @@ Mappings:
       "family": "aurora-postgresql11"
     "11.6":
       "family": "aurora-postgresql11"
+    "11.7":
+      "family": "aurora-postgresql11"
 Conditions:
   IsDBMultiAZ:
     !Equals
@@ -176,6 +178,7 @@ Parameters:
       - 10.7
       - 11.4
       - 11.6
+      - 11.7
   DBInstanceClass:
     AllowedValues:
       - db.r5.large


### PR DESCRIPTION
We can push these changes all the way up to AWS Org in preparation for the QS templates themselves.

As well as being able to select between `v9` and `v10`, we now need support for `v11` as documented [here](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Updates.20180305.html)

Adding:

- `11.4`
- `11.6`
- `11.7`