### PR TITLE
DCD-1051: Refactor code

### DIFF
--- a/templates/aurora_postgres.template.yaml
+++ b/templates/aurora_postgres.template.yaml
@@ -126,9 +126,6 @@ Conditions:
     !Equals
     - !Ref CustomDBSecurityGroup
     - ''
-  GovCloudCondition: !Equals
-    - !Ref 'AWS::Region'
-    - us-gov-west-1
 Outputs:
   DBName: 
     Description: "Amazon Aurora database name"
@@ -334,8 +331,7 @@ Resources:
           - Effect: Allow
             Principal:
               AWS: !Sub
-                - arn:${ArnPartition}:iam::${AWS::AccountId}:root
-                - ArnPartition: !If ["GovCloudCondition", "aws-us-gov", "aws"]
+                - arn:${AWS::Partition}:iam::${AWS::AccountId}:root
             Action: 'kms:*'
             Resource: '*'
       Tags:


### PR DESCRIPTION
Simplifying this code

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html

> AWS::Partition
> Returns the partition that the resource is in. For standard AWS regions, the partition is aws. For resources in other > partitions, the partition is aws-partitionname. For example, the partition for resources in the China (Beijing and Ningxia) > region is aws-cn and the partition for resources in the AWS GovCloud (US-West) region is aws-us-gov. 