### PR TITLE
GitHub action for linting CFN templates 

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,0 +1,11 @@
+templates:
+  - templates/*
+  
+# Used by cfn-lint GitHub Action
+ignore_checks:
+  # W4002: As the resource "metadata" section contains reference to a "NoEcho" parameter DBMasterUserPassword, CloudFormation will display the parameter value in plaintext
+  - W4002
+  # E3012: Property Resources/EFSCname/Properties/TTL should be of type Long
+  - E3012
+  # E1001: Top level template section tests is not valid
+  - E1001

--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -9,3 +9,7 @@ ignore_checks:
   - E3012
   # E1001: Top level template section tests is not valid
   - E1001
+  # W3011: Both UpdateReplacePolicy and DeletionPolicy are needed to protect Resources/EncryptionKey from deletion
+  - W3011
+  # E3029: You cannot specify CopyTagsToSnapshot for Aurora AWS::RDS::DBInstance at Resources/AuroraDB3/Properties/CopyTagsToSnapshot
+  - E3029

--- a/.github/workflows/cfn-lint.yml
+++ b/.github/workflows/cfn-lint.yml
@@ -1,0 +1,17 @@
+name: Lint CloudFormation Templates
+
+on: [push]
+
+jobs:
+  cloudformation-linter:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: cfn-lint
+        uses: scottbrenner/cfn-lint-action@master
+        with:
+          args: "templates/*.yaml"


### PR DESCRIPTION
Lint CFN templates before merging. Were using the following GitHub action for this:

https://github.com/marketplace/actions/cfn-lint-action

which consumes the current .cfnlintrc file.

This action will also make commentary directly against the PR files themselves:

![image](https://user-images.githubusercontent.com/409063/88258034-813b5780-cd02-11ea-8567-2be90e7a427a.png)
