### PR TITLE
DCD-1223: Add option for postgres 12 in DBEngineVersion

### DIFF
--- a/templates/aurora_postgres.template.yaml
+++ b/templates/aurora_postgres.template.yaml
@@ -104,6 +104,8 @@ Mappings:
       "family": "aurora-postgresql11"
     "11.7":
       "family": "aurora-postgresql11"
+    "12.4":
+      "family": "aurora-postgresql12"
 Conditions:
   IsDBMultiAZ:
     !Equals

--- a/templates/aurora_postgres.template.yaml
+++ b/templates/aurora_postgres.template.yaml
@@ -179,6 +179,7 @@ Parameters:
       - 11.4
       - 11.6
       - 11.7
+      - 12.4
   DBInstanceClass:
     AllowedValues:
       - db.r5.large

--- a/templates/aurora_postgres.template.yaml
+++ b/templates/aurora_postgres.template.yaml
@@ -355,7 +355,6 @@ Resources:
       EngineVersion: !Ref DBEngineVersion
       DBParameterGroupName: !Ref DBParamGroup
       PubliclyAccessible: false
-      CopyTagsToSnapshot: true
       Tags:
         -
           Key: Name
@@ -389,7 +388,6 @@ Resources:
       EngineVersion: !Ref DBEngineVersion
       DBParameterGroupName: !Ref DBParamGroup
       PubliclyAccessible: false
-      CopyTagsToSnapshot: true
       Tags:
         -
           Key: Name
@@ -423,7 +421,6 @@ Resources:
       Engine: aurora-postgresql
       DBParameterGroupName: !Ref DBParamGroup
       PubliclyAccessible: false
-      CopyTagsToSnapshot: true
       Tags:
         -
           Key: Name


### PR DESCRIPTION
12.4 is latest version supported by Aurora postgres
```
aws rds describe-db-engine-versions --engine aurora-postgresql --query '*[].[EngineVersion]' --output text --region ap-southeast-2        
9.6.3
9.6.6
9.6.8
9.6.9
9.6.11
9.6.12
9.6.16
9.6.17
9.6.18
9.6.19
10.5
10.6
10.7
10.11
10.12
10.12
10.13
10.14
11.6
11.7
11.8
11.9
12.4
```